### PR TITLE
Tests I extended which fail unexpectedly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <maven-site-plugin.version>3.4</maven-site-plugin.version>
     <!-- End of updated versions required for "mvn site" -->
     <maven-surefire-plugin.version>2.18.1</maven-surefire-plugin.version>
-    <jgit.version>3.6.1.201501031845-r</jgit.version>
+    <jgit.version>3.6.2.201501210735-r</jgit.version>
   </properties>
 
   <dependencies>

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CliGitAPIImpl.java
@@ -469,7 +469,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
                         .execute();;
                 setRemoteUrl(origin, url);
                 for (RefSpec refSpec : refspecs) {
-                  launchCommand("config", "remote." + origin + ".fetch", refSpec.toString());
+                  launchCommand("config", "--add", "remote." + origin + ".fetch", refSpec.toString());
                 }
             }
 
@@ -1579,10 +1579,7 @@ public class CliGitAPIImpl extends LegacyCompatibleGitAPIImpl {
     }
 
     public Set<Branch> getBranches() throws GitException, InterruptedException {
-        // git branch -a will return remote branches prefixed by remotes/,
-        // while git branch -r will return them with the correct name
-        return Sets.union(parseBranches(launchCommand("branch")),
-                          parseBranches(launchCommand("branch", "-r")));
+        return parseBranches(launchCommand("branch", "-a"));
     }
 
     public Set<Branch> getRemoteBranches() throws GitException, InterruptedException {

--- a/src/main/java/org/jenkinsci/plugins/gitclient/CloneCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/CloneCommand.java
@@ -1,5 +1,9 @@
 package org.jenkinsci.plugins.gitclient;
 
+import java.util.List;
+
+import org.eclipse.jgit.transport.RefSpec;
+
 /**
  * Command to clone a repository. This command behaves differently from CLI clone command, it never actually checks out
  * into the workspace.
@@ -32,4 +36,8 @@ public interface CloneCommand extends GitCommand {
      */
     @Deprecated
     CloneCommand noCheckout();
+
+    CloneCommand tags(boolean tags);
+
+    CloneCommand refspecs(List<RefSpec> refspecs);
 }

--- a/src/main/java/org/jenkinsci/plugins/gitclient/FetchCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/gitclient/FetchCommand.java
@@ -17,4 +17,6 @@ public interface FetchCommand extends GitCommand {
     FetchCommand shallow(boolean shallow);
     
     FetchCommand timeout(Integer timeout);
+
+    FetchCommand tags(boolean tags);
 }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/CliGitAPIImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/CliGitAPIImplTest.java
@@ -181,7 +181,8 @@ public class CliGitAPIImplTest extends GitAPITestCase {
         VersionTest[] versions = {
             new VersionTest(true,  1, 7, 1,  0),
             new VersionTest(true,  1, 7, 0, 99),
-            new VersionTest(false, 1, 7, 1,  1)
+            new VersionTest(false, 1, 7, 1,  1),
+            new VersionTest(false, 1, 7, 2,  0)
         };
         doTest("git version 1.7.1", versions);
     }
@@ -202,6 +203,15 @@ public class CliGitAPIImplTest extends GitAPITestCase {
             new VersionTest(false, 1, 8, 3, 3)
         };
         doTest("git version 1.8.3.2", versions);
+    }
+
+    public void test_git_version_ubuntu_14_04_ppa() {
+        VersionTest[] versions = {
+            new VersionTest(true,  2, 2, 2, 0),
+            new VersionTest(true,  2, 2, 1, 0),
+            new VersionTest(false, 2, 2, 3, 0)
+        };
+        doTest("git version 2.2.2", versions);
     }
 
     @Override

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -1152,6 +1152,28 @@ public abstract class GitAPITestCase extends TestCase {
 
     }
 
+    @NotImplementedInJGit
+    public void test_fetch_shallow() throws Exception {
+        w.init();
+        w.git.setRemoteUrl("origin", localMirror());
+        w.git.fetch_().from(new URIish("origin"), Collections.singletonList(new RefSpec("refs/heads/*:refs/remotes/origin/*"))).shallow(true).execute();
+        check_remote_url("origin");
+        assertBranchesExist(w.git.getBranches(), "origin/master");
+        final String alternates = ".git" + File.separator + "objects" + File.separator + "info" + File.separator + "alternates";
+        assertFalse("Alternates file found: " + alternates, w.exists(alternates));
+        final String shallow = ".git" + File.separator + "shallow";
+        assertTrue("Shallow file not found: " + shallow, w.exists(shallow));
+    }
+
+    public void test_fetch_noTags() throws Exception {
+        w.init();
+        w.git.setRemoteUrl("origin", localMirror());
+        w.git.fetch_().from(new URIish("origin"), Collections.singletonList(new RefSpec("refs/heads/*:refs/remotes/origin/*"))).tags(false).execute();
+        check_remote_url("origin");
+        assertBranchesExist(w.git.getBranches(), "origin/master");
+        Set<String> tags = w.git.getTagNames("");
+        assertTrue("Tags have been found : " + tags, tags.isEmpty());
+    }
 
     public void test_create_branch() throws Exception {
         w.init();

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -564,6 +564,23 @@ public abstract class GitAPITestCase extends TestCase {
         });
     }
 
+    @NotImplementedInJGit
+    public void test_clone_refspecs() throws Exception {
+      List<RefSpec> refspecs = Lists.newArrayList(
+          new RefSpec("+refs/heads/master:refs/remotes/origin/master"),
+          new RefSpec("+refs/heads/1.4.x:refs/remotes/origin/1.4.x")
+      );
+      w.git.clone_().url(localMirror()).refspecs(refspecs).repositoryName("origin").execute();
+      w.git.withRepository(new RepositoryCallback<Void>() {
+        public Void invoke(Repository repo, VirtualChannel channel) throws IOException, InterruptedException {
+          String[] fetchRefSpecs = repo.getConfig().getStringList(ConfigConstants.CONFIG_REMOTE_SECTION, Constants.DEFAULT_REMOTE_NAME, "fetch");
+          assertEquals("Expected 2 refspecs", 2, fetchRefSpecs.length);
+          assertEquals("Incorrect refspec 1", "+refs/heads/master:refs/remotes/origin/master", fetchRefSpecs[0]);
+          assertEquals("Incorrect refspec 2", "+refs/heads/1.4.x:refs/remotes/origin/1.4.x", fetchRefSpecs[1]);
+          return null;
+        }});
+    }
+
     public void test_detect_commit_in_repo() throws Exception {
         w.init();
         w.touch("file1");
@@ -1158,7 +1175,7 @@ public abstract class GitAPITestCase extends TestCase {
         w.git.setRemoteUrl("origin", localMirror());
         w.git.fetch_().from(new URIish("origin"), Collections.singletonList(new RefSpec("refs/heads/*:refs/remotes/origin/*"))).shallow(true).execute();
         check_remote_url("origin");
-        assertBranchesExist(w.git.getBranches(), "origin/master");
+        assertBranchesExist(w.git.getRemoteBranches(), "origin/master");
         final String alternates = ".git" + File.separator + "objects" + File.separator + "info" + File.separator + "alternates";
         assertFalse("Alternates file found: " + alternates, w.exists(alternates));
         final String shallow = ".git" + File.separator + "shallow";
@@ -1170,7 +1187,7 @@ public abstract class GitAPITestCase extends TestCase {
         w.git.setRemoteUrl("origin", localMirror());
         w.git.fetch_().from(new URIish("origin"), Collections.singletonList(new RefSpec("refs/heads/*:refs/remotes/origin/*"))).tags(false).execute();
         check_remote_url("origin");
-        assertBranchesExist(w.git.getBranches(), "origin/master");
+        assertBranchesExist(w.git.getRemoteBranches(), "origin/master");
         Set<String> tags = w.git.getTagNames("");
         assertTrue("Tags have been found : " + tags, tags.isEmpty());
     }

--- a/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/gitclient/GitAPITestCase.java
@@ -614,7 +614,11 @@ public abstract class GitAPITestCase extends TestCase {
         });
     }
 
-    public void test_fetch_refspecs() throws Exception {
+    /** This test needs to assert the results of the fetch, not the
+     * contents of the config file, since the fetch is run without
+     * updating the config file
+     */
+    public void xtest_fetch_refspecs() throws Exception {
         final String masterRefspec = "+refs/heads/master:refs/remotes/origin/master";
         final String r14xRefspec = "+refs/heads/1.4.x:refs/remotes/origin/1.4.x";
         final List<RefSpec> refspecs = Lists.newArrayList(


### PR DESCRIPTION
Vincent,

I thought your tests were a good pattern, but did not understand why you marked one of the refspec tests as not implemented in JGit.  Can you explain further why it is not implemented in JGit?

I also attempted the same type of operation with a git fetch_() and was surprised that multiple refspecs are accepted as arguments, but are not written to the git config file.  Does that surprise you?
